### PR TITLE
Update to use esprima-fb

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var parse = require('esprima').parse;
+var parse = require('esprima-fb').parse;
 
 module.exports = function (src) {
     var ast = parse(src, { range: true });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "concat-stream": "~1.2.1",
-    "esprima": "~1.0.4",
+    "esprima-fb": "^3001.1.0-dev-harmony-fb",
     "minimist": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Keeps browser-unpack behaving the same as browserify and its dependencies, given the changes in 3.33.x :)
