### PR TITLE
Handle "EmptyStatement" nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ var parse = require('esprima').parse;
 
 module.exports = function (src) {
     var ast = parse(src, { range: true });
+
+    ast.body = ast.body.filter(function(node) {
+        return node.type !== 'EmptyStatement';
+    });
+
     if (ast.body.length !== 1) return;
     if (ast.body[0].type !== 'ExpressionStatement') return;
     if (ast.body[0].expression.type === 'UnaryExpression') {

--- a/test/empty-statements.js
+++ b/test/empty-statements.js
@@ -1,0 +1,17 @@
+var test = require('tape');
+var unpack = require('../');
+var pack = require('browser-pack');
+var concat = require('concat-stream');
+var vm = require('vm');
+
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/empty-statements.js', 'utf8');
+
+test('uglified', function (t) {
+    t.plan(2);
+    t.doesNotThrow(function() {
+        var p = pack({ raw: true });
+        var rows = unpack(src);
+        t.equal(rows.length, 3, 'should unpack 3 rows');
+    }, 'should not throw');
+});

--- a/test/files/empty-statements.js
+++ b/test/files/empty-statements.js
@@ -1,0 +1,80 @@
+;;(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+// transliterated from the python snippet here:
+// http://en.wikipedia.org/wiki/Lanczos_approximation
+
+var g = 7;
+var p = [
+    0.99999999999980993,
+    676.5203681218851,
+    -1259.1392167224028,
+    771.32342877765313,
+    -176.61502916214059,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.9843695780195716e-6,
+    1.5056327351493116e-7
+];
+
+var g_ln = 607/128;
+var p_ln = [
+    0.99999999999999709182,
+    57.156235665862923517,
+    -59.597960355475491248,
+    14.136097974741747174,
+    -0.49191381609762019978,
+    0.33994649984811888699e-4,
+    0.46523628927048575665e-4,
+    -0.98374475304879564677e-4,
+    0.15808870322491248884e-3,
+    -0.21026444172410488319e-3,
+    0.21743961811521264320e-3,
+    -0.16431810653676389022e-3,
+    0.84418223983852743293e-4,
+    -0.26190838401581408670e-4,
+    0.36899182659531622704e-5
+];
+
+// Spouge approximation (suitable for large arguments)
+function lngamma(z) {
+
+    if(z < 0) return Number('0/0');
+    var x = p_ln[0];
+    for(var i = p_ln.length - 1; i > 0; --i) x += p_ln[i] / (z + i);
+    var t = z + g_ln + 0.5;
+    return .5*Math.log(2*Math.PI)+(z+.5)*Math.log(t)-t+Math.log(x)-Math.log(z);
+}
+
+module.exports = function gamma (z) {
+    if (z < 0.5) {
+        return Math.PI / (Math.sin(Math.PI * z) * gamma(1 - z));
+    }
+    else if(z > 100) return Math.exp(lngamma(z));
+    else {
+        z -= 1;
+        var x = p[0];
+        for (var i = 1; i < g + 2; i++) {
+            x += p[i] / (z + i);
+        }
+        var t = z + g + 0.5;
+
+        return Math.sqrt(2 * Math.PI)
+            * Math.pow(t, z + 0.5)
+            * Math.exp(-t)
+            * x
+        ;
+    }
+};
+
+module.exports.log = lngamma;
+
+},{}],2:[function(require,module,exports){
+module.exports = function (n) { return n * 111 }
+
+},{}],3:[function(require,module,exports){
+var foo = require('./foo.js');
+var gamma = require('gamma');
+
+console.log(Math.floor(foo(gamma(3.8))));
+
+},{"./foo.js":2,"gamma":1}]},{},[3])
+;;


### PR DESCRIPTION
Extra semicolons added to the root of the browserify bundle will result in a body node with >1 children. By filtering these out, these semicolons become inconsequential. Thanks!
