### PR TITLE
Using ecmaVersion 8 for acorn

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (src) {
 
     var ast = parse(src, {
       range: true,
-      ecmaVersion: 6
+      ecmaVersion: 8
     });
 
     ast.body = ast.body.filter(function(node) {


### PR DESCRIPTION
Lets use ecmaVersion 8 just like we did in `bundle-collapser`:

https://github.com/substack/bundle-collapser/commit/5ff52c578ef74d586b5538c85efb27bca7cc2e4d