### PR TITLE
Use acorn-node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "browser-unpack": "bin/cmd.js"
   },
   "dependencies": {
-    "acorn": "^5.6.2",
+    "acorn-node": "^1.5.2",
     "concat-stream": "^1.5.0",
     "minimist": "^1.1.1"
   },


### PR DESCRIPTION
This module tracks TC39 proposals that have landed in Node, and that may have been used to generate a browserify bundle.